### PR TITLE
git attributes to ignore false modified files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Inside the container may throw false positives to already commited files due to file ending conversion inside the linux container. I've added the recommended git attributes to .gitattributes to avoid these.